### PR TITLE
Rebuild fastparquet 0.5.0 for python 3.10 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,9 @@ source:
 
 build:
   number: 2
+  # Currently it's not available on s390x:
+  # There is a missing numba package.
+  skip: True  # [py<37 or s390x]
   script:
     - del fastparquet\*.c  # [win]
     - rm fastparquet/*.c   # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,11 +47,12 @@ test:
     - pip check || exit 0  # [win]
   requires:
     - pip
+    - numpy <1.22
 
 about:
   home: https://github.com/dask/fastparquet
-  license: BSD-3-Clause
-  license_family: BSD
+  license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
   summary: 'Python interface to the parquet format'
   dev_url: https://github.com/dask/fastparquet

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,9 @@ requirements:
     - pandas >=1.1.0
     - {{ pin_compatible('numpy') }}
     - thrift >=0.11
+  run_constrained:
+    # numpy has a hard upper limit currently for numba 0.55.1
+    - numpy >=1.18,<1.22
 
 test:
   imports:
@@ -47,7 +50,6 @@ test:
     - pip check || exit 0  # [win]
   requires:
     - pip
-    - numpy <1.22
 
 about:
   home: https://github.com/dask/fastparquet

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   number: 2
   # Currently it's not available on s390x:
   # There is a missing numba package.
-  skip: True  # [py<37 or s390x]
+  skip: True  # [py<36 or s390x]
   script:
     - del fastparquet\*.c  # [win]
     - rm fastparquet/*.c   # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,18 +4,18 @@
 
 package:
   name: {{ name }}
-  version: "{{ version }}"
+  version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/f/{{ name }}/{{ name }}-{{ version  }}.tar.gz
-  sha256: "{{ sha256 }}"
+  sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   script:
     - del fastparquet\*.c  # [win]
     - rm fastparquet/*.c   # [unix]
-    - "{{ PYTHON }} -m pip install . --no-deps -vv "
+    - {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   build:
@@ -23,33 +23,39 @@ requirements:
   host:
     - python
     - cython
+    - numba
+    - numpy
+    - packaging
     - pandas
     - pip
-    - setuptools
-    - numpy
     - pytest-runner
-    - numba
-    - packaging
-    - thrift 0.11
+    - setuptools
+    - thrift >=0.11
   run:
     - python
-    - pandas >=0.19
-    - numpy
+    - numba >=0.49
     - packaging
-    - numba >=0.28
-    - thrift 0.11
+    - pandas >=1.1.0
+    - {{ pin_compatible('numpy') }}
+    - thrift >=0.11
 
 test:
   imports:
     - fastparquet
+  commands:
+    - pip check || true    # [not win]
+    - pip check || exit 0  # [win]
+  requires:
+    - pip
 
 about:
-  home: http://github.com/dask/fastparquet
-  license: BSD-3
-  license_family: 'BSD'
+  home: https://github.com/dask/fastparquet
+  license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
   summary: 'Python interface to the parquet format'
   dev_url: https://github.com/dask/fastparquet
+  doc_url: https://github.com/dask/fastparquet/blob/main/docs/source/quickstart.rst
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
License: https://github.com/dask/fastparquet/blob/0.5.0/LICENSE
Requirements:
- https://github.com/dask/fastparquet/blob/0.5.0/requirements.txt
- https://github.com/dask/fastparquet/blob/0.5.0/setup.py

Actions:
1. Bump build number to `2`
2. Skip `py<36`
3. Fix pinning for `thrift >=0.11`
4. Update pinnings for run dependencies
5. Add  `run_constrained`:
```
    # numpy has a hard upper limit currently for numba 0.55.1
    - numpy >=1.18,<1.22
```
6. Add `pip check`
7. Fix home url
8. Fix license name and license_family
9. Add `doc_url`
