### PR TITLE
2024.2.0 update

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - git  # [not win]
-    - cython >=0.29.23
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   skip: true  # [py<38 or s390x]
   script: 
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-    # this avoids conflicts with cython built files and allows them to be imported
+    # this avoids conflicts with cython built files and allows them to be imported during test phase
     -  mv ./fastparquet ./fastparquet-src
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - setuptools-scm >1.5.4
     - numpy {{ numpy }}
     - cython >=0.29.23
-    - packaging
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -46,9 +45,7 @@ test:
     - fastparquet.speedups
   requires:
     - pip
-    - pytest
   commands:
-    - pytest -v fastparquet/test
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,8 +37,6 @@ requirements:
     - packaging
 
 test:
-  source_files:
-    - fastparquet/test
   imports:
     - fastparquet
     - fastparquet.cencoding

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fastparquet" %}
-{% set version = "2023.8.0" %}
+{% set version = "2024.2.0" %}
 
 package:
   name: {{ name }}
@@ -7,26 +7,32 @@ package:
 
 source:
   url: https://pypi.io/packages/source/f/{{ name }}/{{ name }}-{{ version  }}.tar.gz
-  sha256: 2ff39bc20869829ea8fd85bf0336c5006d0ffcc276d0de070030cf8ffd929160
+  sha256: 81a8f60c51793eb2436b4fdbbf115ff8578a4a457a179240bc08f9d9573d57a4
 
 build:
   number: 0
   #skip s390x because of lack of cramjam and numba
   skip: true  # [py<38 or s390x]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  script: 
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+    # this avoids conflicts with cython built files and allows them to be imported
+    -  mv ./fastparquet ./fastparquet-src
 
 requirements:
   build:
     - {{ compiler('c') }}
     - git  # [not win]
+    - cython >=0.29.23
   host:
     - python
     - pip
     - wheel
     - setuptools
+    - setuptools-scm >1.5.4
     - numpy {{ numpy }}
-    - cython 0.29
+    - cython >=0.29.23
     - pytest-runner
+    - packaging
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -36,8 +42,12 @@ requirements:
     - packaging
 
 test:
+  source_files:
+    - fastparquet-src
   imports:
     - fastparquet
+    - fastparquet.cencoding
+    - fastparquet.speedups
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,8 +15,6 @@ build:
   skip: true  # [py<38 or s390x]
   script: 
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-    # this avoids conflicts with cython built files and allows them to be imported during test phase
-    -  mv ./fastparquet ./fastparquet-src
 
 requirements:
   build:
@@ -30,7 +28,6 @@ requirements:
     - setuptools-scm >1.5.4
     - numpy {{ numpy }}
     - cython >=0.29.23
-    - pytest-runner
     - packaging
   run:
     - python
@@ -42,14 +39,16 @@ requirements:
 
 test:
   source_files:
-    - fastparquet-src
+    - fastparquet/test
   imports:
     - fastparquet
     - fastparquet.cencoding
     - fastparquet.speedups
   requires:
     - pip
+    - pytest
   commands:
+    - pytest -v fastparquet/test
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,7 @@ build:
   number: 0
   #skip s390x because of lack of cramjam and numba
   skip: true  # [py<38 or s390x]
-  script: 
-    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:


### PR DESCRIPTION
[fastparquet-feedstock](https://github.com/AnacondaRecipes/fastparquet-feedstock) 2024.2.0

**Destination channel:** defaults

### Links

- [PKG-4507](https://anaconda.atlassian.net/browse/PKG-4507) 
- [Upstream repository](https://github.com/dask/fastparquet)
- [Upstream changelog/diff](https://github.com/dask/fastparquet/releases/tag/2024.2.0)

### Explanation of changes:
- update version, enhance dependencies, update pinnings, and increase testing

[PKG-4507]: https://anaconda.atlassian.net/browse/PKG-4507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ